### PR TITLE
Feat/bind_device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ offload = []
 tun = { version = "0.6", features = ["async"] }
 netstack-lwip = { git = "https://github.com/Watfaq/netstack-lwip.git", rev = "2817bf82740e04bbee6b7bf1165f55657a6ed163" }
 structopt = "0.3"
+shadowsocks = "1.18"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,34 @@ tokio::spawn(async move {
 });
 ```
 
+## examples
+
+the example `proxy` uses our crate - `netstack-smoltcp` as the userspace implementation, you can run it via 
+
+1. `sudo cargo run --example proxy -- --interface /your/if/name` (macos & linux)
+2. `cargo run run --example proxy -- --interface /your/if/name` (windows, but you need to run the terminal as admin)
+
+but on windows, you should also have `wintun.dll` installed in `C:\Windows\System32`
+
+after that, you can set the route table by the following instructions:
+
+### windows(run terminal as admin)
+
+1. `Get-NetAdapter` to check the utun8's if index, assume the index is `INDEX`
+2. `route add 1.1.1.1 mask 255.255.255.255 10.10.10..2 if INDEX`
+
+### linux
+
+`sudo ip route add 1.1.1.1/32 dev utun8`
+
+### macos 
+
+`sudo route add 146.190.81.132 -interface utun8`
+
+so now the have both the proxy program running and the routing table setup correctly, we can have a shot by running: `curl 1.1.1.1`
+
+or, you can replace the `1.1.1.1` with your server's ipv4 address, and run the iperf3 performance test.
+
 ## benchmark 
 
 see [benchmark result](./benchmark.md)

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -2,7 +2,11 @@ use std::net::SocketAddr;
 
 use futures::{SinkExt, StreamExt};
 use netstack_smoltcp::{StackBuilder, TcpListener, UdpSocket};
-use tokio::net::{TcpSocket, TcpStream};
+#[allow(unused)]
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::{TcpSocket, TcpStream},
+};
 use tracing::warn;
 use tun::{Device, TunPacket};
 
@@ -120,16 +124,16 @@ async fn main() {
 // simply forward
 async fn handle_inbound_stream(mut tcp_listener: TcpListener, interface: &str) {
     loop {
-        while let Some((mut stream, local, remote)) = tcp_listener.next().await {
+        while let Some((mut stream, local_addr, remote_addr)) = tcp_listener.next().await {
             let interface = interface.to_owned();
             tokio::spawn(async move {
-                println!("new tcp connection: {:?} => {:?}", local, remote);
-                if let Ok(mut remote) = new_tcp_stream(remote, &interface).await {
+                println!("new tcp connection: {:?} => {:?}", local_addr, remote_addr);
+                if let Ok(mut remote) = new_tcp_stream(remote_addr, &interface).await {
                     match tokio::io::copy_bidirectional(&mut stream, &mut remote).await {
                         Ok(_) => {}
                         Err(e) => warn!(
                             "failed to copy tcp stream {:?}=>{:?}, err: {:?}",
-                            local, remote, e
+                            local_addr, remote_addr, e
                         ),
                     }
                 }
@@ -201,27 +205,29 @@ fn get_device_broadcast(device: &tun::AsyncDevice) -> Option<std::net::Ipv4Addr>
     }
 }
 
-pub async fn new_tcp_stream<'a>(addr: SocketAddr, iface: &str) -> std::io::Result<TcpStream> {
-    let socket = socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None)?;
+pub trait ProxyStream: AsyncRead + AsyncWrite + Send + Unpin {}
+impl<T> ProxyStream for T where T: AsyncRead + AsyncWrite + Send + Unpin {}
+pub type AnyStream = Box<dyn ProxyStream>;
 
-    socket.bind_device(Some(iface.as_bytes()))?;
-    socket.set_keepalive(true)?;
-    socket.set_nodelay(true)?;
-    socket.set_nonblocking(true)?;
+pub async fn new_tcp_stream(addr: SocketAddr, iface: &str) -> std::io::Result<AnyStream> {
+    use shadowsocks::net::*;
+    let mut opts: ConnectOpts = ConnectOpts::default();
+    opts.bind_interface = Some(iface.to_owned());
 
-    let stream = TcpSocket::from_std_stream(socket.into())
-        .connect(addr)
-        .await?;
-
-    Ok(stream)
+    shadowsocks::net::TcpStream::connect_with_opts(&addr, &opts)
+        .await
+        .map(|x| Box::new(x) as _)
 }
 
-pub async fn new_udp_packet(iface: Option<&str>) -> std::io::Result<tokio::net::UdpSocket> {
-    let socket = socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None)?;
-    if let Some(iface) = iface {
-        socket.bind_device(Some(iface.as_bytes()))?;
-    }
-    socket.set_nonblocking(true)?;
+pub async fn new_udp_packet(
+    addr: &SocketAddr,
+    iface: &str,
+) -> std::io::Result<tokio::net::UdpSocket> {
+    use shadowsocks::net::*;
+    let mut opts = ConnectOpts::default();
+    opts.bind_interface = Some(iface.to_owned());
 
-    tokio::net::UdpSocket::from_std(socket.into())
+    shadowsocks::net::UdpSocket::connect_with_opts(addr, &opts)
+        .await
+        .map(|x| x.into())
 }


### PR DESCRIPTION
use shadowsocks-rust's wrap of `bind interface` to support binding of tun device on multiple platforms; windows & linux & macos are supported now